### PR TITLE
Add Audio Library "Cleaning"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,84 +1,111 @@
-# media_cleaner.py
+# Script
+## media_cleaner.py
 This script will go through all played movies, tv episodes, videos, trailers, and audio for the specified user; deleting any media past the specified played age cut off.
 
-# media_cleaner_config.py
+# Configuration
+## media_cleaner_config.py
 The first time you run the script it will attempt to create the config file by asking a few questions.
 
-
-----------------------------------------------------------
- Delete media type once it has been played x days ago
-   0-365000000 - number of days to wait before deleting played media
-  -1 : to disable managing specified media type
- (-1 : default)
-----------------------------------------------------------
+## Configuration Contents
+#### Media will be deleted once it has been played the number of days ago configured below:
+```python
+#----------------------------------------------------------#
+# Delete media type once it has been played x days ago
+#   0-365000000 - number of days to wait before deleting played media
+#  -1 : to disable managing specified media type
+# (-1 : default)
+#----------------------------------------------------------#
 not_played_age_movie=-1
 not_played_age_episode=-1
 not_played_age_video=-1
 not_played_age_trailer=-1
 not_played_age_audio=-1
-
-----------------------------------------------------------
- Favoriting a series or season will treat all child episodes as if they are favorites
- Favoriting an artist, album-artist, or album will treat all child tracks as if they are favorites
-  0 : ok to delete movie played not_played_age_movie=x days ago
-  1 : do no delete movie played not_played_age_movie=x days ago
- (1 : default)
- Same applies for other media types (episodes, trailers, etc...)
-----------------------------------------------------------
+```
+#### When enabled, media will not be deleted if it is marked as a favorite:
+```python
+#----------------------------------------------------------#
+# Favoriting a series or season will treat all child episodes as if they are favorites
+# Favoriting an artist, album-artist, or album will treat all child tracks as if they are favorites
+#  0 : ok to delete movie played not_played_age_movie=x days ago
+#  1 : do no delete movie played not_played_age_movie=x days ago
+# (1 : default)
+# Same applies for other media types (episodes, trailers, etc...)
+#----------------------------------------------------------#
 keep_favorites_movie=1
 keep_favorites_episode=1
 keep_favorites_video=1
 keep_favorites_trailer=1
 keep_favorites_audio=1
-
-----------------------------------------------------------
- Advanced audio favorites configuration bitmask
-     Requires keep_favorites_audio=1
-  xxxxA - keep audio tracks based only on the first artist listed in the track's 'artist' metadata is favorited
-  xxxBx - keep audio tracks based only on the first artist listed in the tracks's 'album artist' metadata is favorited
-  xxCxx - work In Progress...
-  xDxxx - work In Progress...
-  Exxxx - work In Progress...
-  0 bit - disabled
-  1 bit - enabled
- (00001 - default)
-----------------------------------------------------------
+```
+#### Additional options for determining if an audio track should be considered marked as a favorite based on specified metadata item:
+```python
+#----------------------------------------------------------#
+# Advanced audio favorites configuration bitmask
+#     Requires keep_favorites_audio=1
+#  xxxxA - keep audio tracks based only on the first artist listed in the track's 'artist' metadata is favorited
+#  xxxBx - keep audio tracks based only on the first artist listed in the tracks's 'album artist' metadata is favorited
+#  xxCxx - work In Progress...
+#  xDxxx - work In Progress...
+#  Exxxx - work In Progress...
+#  0 bit - disabled
+#  1 bit - enabled
+# (00001 - default)
+#----------------------------------------------------------#
 keep_favorites_audio_advanced='00001'
-
-----------------------------------------------------------
- Advanced audio favorites all configuration bitmask
-     Requires matching keep_favorites_audio_advanced bitmask is enabled
-  xxxxa - xxxxA must be enabled above; will use ALL artists listed in the track's 'artist' metadata
-  xxxbx - xxxBx must be enabled above; will use ALL artists listed in the track's 'album artist' metadata
-  xxcxx - work In Progress...
-  xdxxx - work In Progress...
-  exxxx - work In Progress...
-  0 bit - disabled
-  1 bit - enabled
- (00000 - default)
-----------------------------------------------------------
+```
+#### Dependent on the above "advanced audio options", determines if only the first metadata item should be considered or all metadata items should be considered:
+```python
+#----------------------------------------------------------#
+# Advanced audio favorites all configuration bitmask
+#     Requires matching keep_favorites_audio_advanced bitmask is enabled
+#  xxxxa - xxxxA must be enabled above; will use ALL artists listed in the track's 'artist' metadata
+#  xxxbx - xxxBx must be enabled above; will use ALL artists listed in the track's 'album artist' metadata
+#  xxcxx - work In Progress...
+#  xdxxx - work In Progress...
+#  exxxx - work In Progress...
+#  0 bit - disabled
+#  1 bit - enabled
+# (00000 - default)
+#----------------------------------------------------------#
 keep_favorites_audio_advanced_any='00000'
-
-----------------------------------------------------------
- Whitelisting a library folder will treat all child media as if they are favorites
- ('' - default)
-----------------------------------------------------------
-whitelisted_library_folders='/path/to/library/folder0,path/to/libray/folder1,/path/to/library/folderX'
-
-----------------------------------------------------------
- 0 - Disable the ability to delete media (dry run mode)
- 1 - Enable the ability to delete media
- (0 - default)
-----------------------------------------------------------
+```
+#### Media in these library folders will be treated as if they are all marked as a favorite (i.e. media will not be deleted):
+```python
+#----------------------------------------------------------#
+# Whitelisting a library folder will treat all child media as if they are favorites
+# ('' - default)
+#----------------------------------------------------------#
+whitelisted_library_folders='smb://hieroglyph/Pharaoh/xbmc/Movies'
+```
+#### Allows the script to be run without deleting media (i.e. for testing and setup); Set to 1 when ready for "production":
+```python
+#----------------------------------------------------------#
+# 0 - Disable the ability to delete media (dry run mode)
+# 1 - Enable the ability to delete media
+# (0 - default)
+#----------------------------------------------------------#
 remove_files=0
+```
+#### Created first time the script runs; Do not manually change these unless you know what you are doing:
+```python
+#------------DO NOT MODIFY BELOW---------------------------#
 
-------------DO NOT MODIFY BELOW---------------------------
-server_brand='emby' - 0:emby or 1:jellyfin
-server_url='http://localhost:8096/basename' - Server name or ip address
-admin_username='Username' - Username for admin account
-access_token='0123456789abcdef0123456789abcdef0' - Token used to verify admin user requests to server
-user_key='abcdef0123456789abcdef0123456789a' - UserID of the account the script uses to monitor played status
-DEBUG=0 - 0:Do not display debug info; 1:Display debug info 
+#----------------------------------------------------------#
+# Server branding chosen during setup
+#  0 - 'emby'
+#  1 - 'jellyfin'
+# Server URL created during setup
+# Admin username chosen during setup
+# Access token requested from server during setup
+# User key of account to monitor played media chosen during setup
+#----------------------------------------------------------#
+server_brand='xyz'
+server_url='http://localhost.tld:8096/basename'
+admin_username='Username'
+access_token='0123456789abcdef0123456789abcdef0'
+user_key='abcdef0123456789abcdef0123456789a'
+DEBUG=0
+```
 
 # Usage
 Make media_cleaner.py executable and run ./media_cleaner.py.  If no conifg file is found it will prompt you to create one.  Once done you can run the script again to view files that will be deleted

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ whitelisted_library_folders='smb://hieroglyph/Pharaoh/xbmc/Movies'
 #----------------------------------------------------------#
 remove_files=0
 ```
-#### Created first time the script runs; Do NOT change these:
+#### Created first time the script runs; Do **_NOT_** edit these:
 ```python
 #------------DO NOT MODIFY BELOW---------------------------#
 

--- a/README.md
+++ b/README.md
@@ -1,29 +1,84 @@
-# media_cleaner
-This script will go through all watched videos and delete any for a specific user that is older then a defined cutt off.
+# media_cleaner.py
+This script will go through all played movies, tv episodes, videos, trailers, and audio for the specified user; deleting any media past the specified played age cut off.
 
-# Config file 
-The first time you run the script it will attempt to create the config file for you by asking a few questions
+# media_cleaner_config.py
+The first time you run the script it will attempt to create the config file by asking a few questions.
 
-filename: media_cleaner_config.py
 
-* server_brand=0-emby or 1-jellyfin
-* server_url='http://localhost:8096/emby' - Server name or ip address
-* admin_username='UserName' - Username for Admin user with access to delete files
-* admin_password='Password' - Password for Admin user with access to delete files (hashed password stored)
-* access_token='ZZZZZZZZZZZZZ' - Token used to verify admin user actions
-* user_key='YYYYYYYYYYYYY' - UserID of the user that script checks watched status for
-* DEBUG=0 - 0 Do not display debug info; 1 Display debug info
-* not_played_age_movie=100 - How many days to keep a watched movie before deleting; -1 do not delete media type
-* not_played_age_episode=100 - How many days to keep a watched episode before deleting; -1 do not delete media type
-* not_played_age_video=100 - How many days to keep a watched video before deleting; -1 do not delete media type
-* not_played_age_trailer=100 - How many days to keep a watched trailer before deleting; -1 do not delete media type
-* remove_files=0 - 0 for trial runs (media is not deleted);  1 to allow script to delete media
-* keep_favorites_movie=1 - 1 Keep movies that have been marked as favorite; 0 Delete movies marked as favorite
-* keep_favorites_episode=1 - 1 Keep episodes, seasons, and series that have been marked as favorite; 0 Delete episodes marked as favorite
-* keep_favorites_video=1 - 1 Keep videos that have been marked as favorite; 0 Delete videos marked as favorite
-* keep_favorites_trailer=1 - 1 Keep trailers that have been marked as favorite; 0 Delete trailers marked as favorite
-* whitelisted_library_folders='/path/to/library/folder0,path/to/libray/folder1,/path/to/library/folderX' - Keep media in whitelisted library folders; or leave blank
+#----------------------------------------------------------#
+# Delete media type once it has been played x days ago
+#   0-365000000 - number of days to wait before deleting played media
+#  -1 : to disable managing specified media type
+# (-1 : default)
+#----------------------------------------------------------#
+not_played_age_movie=-1
+not_played_age_episode=-1
+not_played_age_video=-1
+not_played_age_trailer=-1
+not_played_age_audio=-1
 
+#----------------------------------------------------------#
+# Favoriting a series or season will treat all child episodes as if they are favorites
+# Favoriting an artist, album-artist, or album will treat all child tracks as if they are favorites
+#  0 : ok to delete movie played not_played_age_movie=x days ago
+#  1 : do no delete movie played not_played_age_movie=x days ago
+# (1 : default)
+# Same applies for other media types (episodes, trailers, etc...)
+#----------------------------------------------------------#
+keep_favorites_movie=1
+keep_favorites_episode=1
+keep_favorites_video=1
+keep_favorites_trailer=1
+keep_favorites_audio=1
+
+#----------------------------------------------------------#
+# Advanced audio favorites configuration bitmask
+#     Requires keep_favorites_audio=1
+#  xxxxA - keep audio tracks based only on the first artist listed in the track's 'artist' metadata is favorited
+#  xxxBx - keep audio tracks based only on the first artist listed in the tracks's 'album artist' metadata is favorited
+#  xxCxx - work In Progress...
+#  xDxxx - work In Progress...
+#  Exxxx - work In Progress...
+#  0 bit - disabled
+#  1 bit - enabled
+# (00001 - default)
+#----------------------------------------------------------#
+keep_favorites_audio_advanced='00001'
+
+#----------------------------------------------------------#
+# Advanced audio favorites all configuration bitmask
+#     Requires matching keep_favorites_audio_advanced bitmask is enabled
+#  xxxxa - xxxxA must be enabled above; will use ALL artists listed in the track's 'artist' metadata
+#  xxxbx - xxxBx must be enabled above; will use ALL artists listed in the track's 'album artist' metadata
+#  xxcxx - work In Progress...
+#  xdxxx - work In Progress...
+#  exxxx - work In Progress...
+#  0 bit - disabled
+#  1 bit - enabled
+# (00000 - default)
+#----------------------------------------------------------#
+keep_favorites_audio_advanced_any='00000'
+
+#----------------------------------------------------------#
+# Whitelisting a library folder will treat all child media as if they are favorites
+# ('' - default)
+#----------------------------------------------------------#
+whitelisted_library_folders='/path/to/library/folder0,path/to/libray/folder1,/path/to/library/folderX'
+
+#----------------------------------------------------------#
+# 0 - Disable the ability to delete media (dry run mode)
+# 1 - Enable the ability to delete media
+# (0 - default)
+#----------------------------------------------------------#
+remove_files=0
+
+#------------DO NOT MODIFY BELOW---------------------------#
+server_brand='emby' - 0:emby or 1:jellyfin
+server_url='http://localhost:8096/basename' - Server name or ip address
+admin_username='Username' - Username for admin account
+access_token='0123456789abcdef0123456789abcdef0' - Token used to verify admin user requests to server
+user_key='abcdef0123456789abcdef0123456789a' - UserID of the account the script uses to monitor played status
+DEBUG=0 - 0:Do not display debug info; 1:Display debug info 
 
 # Usage
 Make media_cleaner.py executable and run ./media_cleaner.py.  If no conifg file is found it will prompt you to create one.  Once done you can run the script again to view files that will be deleted

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ remove_files=0
 # User key of account to monitor played media chosen during setup
 #----------------------------------------------------------#
 server_brand='xyz'
-server_url='http://localhost.tld:8096/basename'
+server_url='http://localhost.abc:8096/basename'
 admin_username='Username'
 access_token='0123456789abcdef0123456789abcdef0'
 user_key='abcdef0123456789abcdef0123456789a'

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ whitelisted_library_folders='smb://hieroglyph/Pharaoh/xbmc/Movies'
 #----------------------------------------------------------#
 remove_files=0
 ```
-#### Created first time the script runs; Do not manually change these:
+#### Created first time the script runs; Do NOT change these:
 ```python
 #------------DO NOT MODIFY BELOW---------------------------#
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This script will go through all played movies, tv episodes, videos, trailers, an
 The first time you run the script it will attempt to create the config file by asking a few questions.
 
 ## Configuration Contents
-#### Media will be deleted once it has been played the number of days ago configured below:
+#### Media will be deleted once it has been played the configured number of days ago:
 ```python
 #----------------------------------------------------------#
 # Delete media type once it has been played x days ago

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ whitelisted_library_folders='smb://hieroglyph/Pharaoh/xbmc/Movies'
 #----------------------------------------------------------#
 remove_files=0
 ```
-#### Created first time the script runs; Do not manually change these unless you know what you are doing:
+#### Created first time the script runs; Do not manually change these:
 ```python
 #------------DO NOT MODIFY BELOW---------------------------#
 

--- a/README.md
+++ b/README.md
@@ -5,74 +5,74 @@ This script will go through all played movies, tv episodes, videos, trailers, an
 The first time you run the script it will attempt to create the config file by asking a few questions.
 
 
-#----------------------------------------------------------#
-# Delete media type once it has been played x days ago
-#   0-365000000 - number of days to wait before deleting played media
-#  -1 : to disable managing specified media type
-# (-1 : default)
-#----------------------------------------------------------#
+----------------------------------------------------------
+ Delete media type once it has been played x days ago
+   0-365000000 - number of days to wait before deleting played media
+  -1 : to disable managing specified media type
+ (-1 : default)
+----------------------------------------------------------
 not_played_age_movie=-1
 not_played_age_episode=-1
 not_played_age_video=-1
 not_played_age_trailer=-1
 not_played_age_audio=-1
 
-#----------------------------------------------------------#
-# Favoriting a series or season will treat all child episodes as if they are favorites
-# Favoriting an artist, album-artist, or album will treat all child tracks as if they are favorites
-#  0 : ok to delete movie played not_played_age_movie=x days ago
-#  1 : do no delete movie played not_played_age_movie=x days ago
-# (1 : default)
-# Same applies for other media types (episodes, trailers, etc...)
-#----------------------------------------------------------#
+----------------------------------------------------------
+ Favoriting a series or season will treat all child episodes as if they are favorites
+ Favoriting an artist, album-artist, or album will treat all child tracks as if they are favorites
+  0 : ok to delete movie played not_played_age_movie=x days ago
+  1 : do no delete movie played not_played_age_movie=x days ago
+ (1 : default)
+ Same applies for other media types (episodes, trailers, etc...)
+----------------------------------------------------------
 keep_favorites_movie=1
 keep_favorites_episode=1
 keep_favorites_video=1
 keep_favorites_trailer=1
 keep_favorites_audio=1
 
-#----------------------------------------------------------#
-# Advanced audio favorites configuration bitmask
-#     Requires keep_favorites_audio=1
-#  xxxxA - keep audio tracks based only on the first artist listed in the track's 'artist' metadata is favorited
-#  xxxBx - keep audio tracks based only on the first artist listed in the tracks's 'album artist' metadata is favorited
-#  xxCxx - work In Progress...
-#  xDxxx - work In Progress...
-#  Exxxx - work In Progress...
-#  0 bit - disabled
-#  1 bit - enabled
-# (00001 - default)
-#----------------------------------------------------------#
+----------------------------------------------------------
+ Advanced audio favorites configuration bitmask
+     Requires keep_favorites_audio=1
+  xxxxA - keep audio tracks based only on the first artist listed in the track's 'artist' metadata is favorited
+  xxxBx - keep audio tracks based only on the first artist listed in the tracks's 'album artist' metadata is favorited
+  xxCxx - work In Progress...
+  xDxxx - work In Progress...
+  Exxxx - work In Progress...
+  0 bit - disabled
+  1 bit - enabled
+ (00001 - default)
+----------------------------------------------------------
 keep_favorites_audio_advanced='00001'
 
-#----------------------------------------------------------#
-# Advanced audio favorites all configuration bitmask
-#     Requires matching keep_favorites_audio_advanced bitmask is enabled
-#  xxxxa - xxxxA must be enabled above; will use ALL artists listed in the track's 'artist' metadata
-#  xxxbx - xxxBx must be enabled above; will use ALL artists listed in the track's 'album artist' metadata
-#  xxcxx - work In Progress...
-#  xdxxx - work In Progress...
-#  exxxx - work In Progress...
-#  0 bit - disabled
-#  1 bit - enabled
-# (00000 - default)
-#----------------------------------------------------------#
+----------------------------------------------------------
+ Advanced audio favorites all configuration bitmask
+     Requires matching keep_favorites_audio_advanced bitmask is enabled
+  xxxxa - xxxxA must be enabled above; will use ALL artists listed in the track's 'artist' metadata
+  xxxbx - xxxBx must be enabled above; will use ALL artists listed in the track's 'album artist' metadata
+  xxcxx - work In Progress...
+  xdxxx - work In Progress...
+  exxxx - work In Progress...
+  0 bit - disabled
+  1 bit - enabled
+ (00000 - default)
+----------------------------------------------------------
 keep_favorites_audio_advanced_any='00000'
 
-#----------------------------------------------------------#
-# Whitelisting a library folder will treat all child media as if they are favorites
-# ('' - default)
-#----------------------------------------------------------#
+----------------------------------------------------------
+ Whitelisting a library folder will treat all child media as if they are favorites
+ ('' - default)
+----------------------------------------------------------
 whitelisted_library_folders='/path/to/library/folder0,path/to/libray/folder1,/path/to/library/folderX'
 
-#----------------------------------------------------------#
-# 0 - Disable the ability to delete media (dry run mode)
-# 1 - Enable the ability to delete media
-# (0 - default)
-#----------------------------------------------------------#
+----------------------------------------------------------
+ 0 - Disable the ability to delete media (dry run mode)
+ 1 - Enable the ability to delete media
+ (0 - default)
+----------------------------------------------------------
 remove_files=0
 
-#------------DO NOT MODIFY BELOW---------------------------#
+------------DO NOT MODIFY BELOW---------------------------
 server_brand='emby' - 0:emby or 1:jellyfin
 server_url='http://localhost:8096/basename' - Server name or ip address
 admin_username='Username' - Username for admin account

--- a/media_cleaner.py
+++ b/media_cleaner.py
@@ -181,7 +181,7 @@ def generate_config():
     #config_file += "#----------------------------------------------------------#\n"
     config_file += "\n"
     config_file += "#----------------------------------------------------------#\n"
-    config_file += "# Favoriting a series or season will treat all child episodes as if they are favorites\n"
+    config_file += "# Favoriting a series, season, or network-channel will treat all child episodes as if they are favorites\n"
     config_file += "# Favoriting an artist, album-artist, or album will treat all child tracks as if they are favorites\n"
     config_file += "#  0 : ok to delete movie played not_played_age_movie=x days ago\n"
     config_file += "#  1 : do no delete movie played not_played_age_movie=x days ago\n"
@@ -197,33 +197,39 @@ def generate_config():
     #config_file += "#----------------------------------------------------------#\n"
     config_file += "\n"
     config_file += "#----------------------------------------------------------#\n"
-    config_file += "# Advanced audio favorites configuration bitmask\n"
-    config_file += "#     Requires 'keep_favorites_audio=1'\n"
-    config_file += "#  xxxxA - keep audio tracks based on if the FIRST artist listed in the track's 'artist' metadata is favorited\n"
-    config_file += "#  xxxBx - keep audio tracks based on if the FIRST artist listed in the tracks's 'album artist' metadata is favorited\n"
-    config_file += "#  xxCxx - genre work in progress...\n"
-    config_file += "#  xDxxx - genre work in progress...\n"
-    config_file += "#  Exxxx - genre work in progress...\n"
+    config_file += "# Advanced favorites configuration bitmask\n"
+    config_file += "#     Requires 'keep_favorites_*=1'\n"
+    config_file += "#  xxxxxxxA - keep audio tracks based on if the FIRST artist listed in the track's 'artist' metadata is favorited\n"
+    config_file += "#  xxxxxxBx - keep audio tracks based on if the FIRST artist listed in the tracks's 'album artist' metadata is favorited\n"
+    config_file += "#  xxxxxCxx - unused...\n"
+    config_file += "#  xxxxDxxx - unused...\n"
+    config_file += "#  xxxExxxx - unused...\n"
+    config_file += "#  xxFxxxxx - unused...\n"
+    config_file += "#  xGxxxxxx - unused...\n"
+    config_file += "#  Hxxxxxxx - unused...\n"
     config_file += "#  0 bit - disabled\n"
     config_file += "#  1 bit - enabled\n"
-    config_file += "# (00001 - default)\n"
+    config_file += "# (00000001 - default)\n"
     config_file += "#----------------------------------------------------------#\n"
-    config_file += "keep_favorites_audio_advanced='00001'\n"
+    config_file += "keep_favorites_advanced='00000001'\n"
     #config_file += "#----------------------------------------------------------#\n"
     config_file += "\n"
     config_file += "#----------------------------------------------------------#\n"
-    config_file += "# Advanced audio favorites any configuration bitmask\n"
-    config_file += "#     Requires matching bit in 'keep_favorites_audio_advanced' bitmask is enabled\n"
-    config_file += "#  xxxxa - xxxxA must be enabled above; will use ANY artists listed in the track's 'artist' metadata\n"
-    config_file += "#  xxxbx - xxxBx must be enabled above; will use ANY artists listed in the track's 'album artist' metadata\n"
-    config_file += "#  xxcxx - genre work in progress...\n"
-    config_file += "#  xdxxx - genre work in progress...\n"
-    config_file += "#  exxxx - genre work in progress...\n"
+    config_file += "# Advanced favorites any configuration bitmask\n"
+    config_file += "#     Requires matching bit in 'keep_favorites_advanced' bitmask is enabled\n"
+    config_file += "#  xxxxxxxa - xxxxxxxA must be enabled above; will use ANY artists listed in the track's 'artist' metadata\n"
+    config_file += "#  xxxxxxbx - xxxxxxBx must be enabled above; will use ANY artists listed in the track's 'album artist' metadata\n"
+    config_file += "#  xxxxxcxx - unused...\n"
+    config_file += "#  xxxxdxxx - unused...\n"
+    config_file += "#  xxxexxxx - unused...\n"
+    config_file += "#  xxfxxxxx - unused...\n"
+    config_file += "#  xgxxxxxx - unused...\n"
+    config_file += "#  hxxxxxxx - unused...\n"
     config_file += "#  0 bit - disabled\n"
     config_file += "#  1 bit - enabled\n"
-    config_file += "# (00000 - default)\n"
+    config_file += "# (00000000 - default)\n"
     config_file += "#----------------------------------------------------------#\n"
-    config_file += "keep_favorites_audio_advanced_any='00000'\n"
+    config_file += "keep_favorites_advanced_any='00000000'\n"
     #config_file += "#----------------------------------------------------------#\n"
     config_file += "\n"
     config_file += "#----------------------------------------------------------#\n"
@@ -551,29 +557,34 @@ def get_additional_item_info(server_url, user_key, itemId, auth_key):
     return(itemInfo)
 
 
-#determinne if track genre, album genre, or artist genre are set to favorite
-def get_isfav_MUSICgentaa(isfav_MUSICgentaa, item, server_url, user_key, auth_key):
-    #Work In Progress...
+def get_studio_item_info(server_url, user_key, studioName, auth_key):
+    #Get studio item information
+    url=server_url + '/Studios/' + urllib.parse.quote(studioName) + '?userId=' + user_key + '&api_key=' + auth_key
 
-    #Set bitmasks
-    adv_settings=int(cfg.keep_favorites_audio_advanced, 2)
-    adv_all=int(cfg.keep_favorites_audio_advanced_any, 2)
-    trackgenre_mask=int('00100', 2)
-    albumgenre_mask=int('01000', 2)
-    artistgenre_mask=int('10000', 2)
-    trackgenre_any_mask=trackgenre
-    albumgenre_any_mask=albumgenre
-    artistgenre_any_mask=artistgenre
+    if bool(cfg.DEBUG):
+        #DEBUG
+        print('-----------------------------------------------------------')
+        print(url)
+    with request.urlopen(url) as response:
+        if response.getcode() == 200:
+            source = response.read()
+            itemInfo = json.loads(source)
+            if bool(cfg.DEBUG):
+                #DEBUG
+                print('get_studio_item_info')
+                print2json(itemInfo)
+        else:
+            print('An error occurred while attempting to retrieve data from the API.')
 
-    return()
+    return(itemInfo)
 
 #determine if track, album, or artist are set to favorite
 def get_isfav_MUSICtaa(isfav_MUSICtaa, item, server_url, user_key, auth_key):
     #Set bitmasks
-    adv_settings=int(cfg.keep_favorites_audio_advanced, 2)
-    adv_all=int(cfg.keep_favorites_audio_advanced_any, 2)
-    trackartist_mask=int('00001', 2)
-    albumartist_mask=int('00010', 2)
+    adv_settings=int(cfg.keep_favorites_advanced, 2)
+    adv_all=int(cfg.keep_favorites_advanced_any, 2)
+    trackartist_mask=int('00000001', 2)
+    albumartist_mask=int('00000010', 2)
     trackartist_any_mask=trackartist_mask
     albumartist_any_mask=albumartist_mask
 
@@ -672,38 +683,44 @@ def get_isfav_MUSICtaa(isfav_MUSICtaa, item, server_url, user_key, auth_key):
 
     return(itemisfav_MUSICtaa)
 
-#determine if episode, season, or series are set to favorite
-def get_isfav_TVess(isfav_TVess, item, server_url, user_key, auth_key):
+#determine if episode, season, series, or network are set to favorite
+def get_isfav_TVessn(isfav_TVessn, item, server_url, user_key, auth_key):
     #Check if episode's favorite value already exists in dictionary
-    if not item['Id'] in isfav_TVess['episode']:
+    if not item['Id'] in isfav_TVessn['episode']:
         #Store if this episode is marked as a favorite
-        isfav_TVess['episode'][item['Id']] = item['UserData']['IsFavorite']
+        isfav_TVessn['episode'][item['Id']] = item['UserData']['IsFavorite']
     #Check if season's favorite value already exists in dictionary
-    if not item['SeasonId'] in isfav_TVess['season']:
+    if not item['SeasonId'] in isfav_TVessn['season']:
         #Store if the season is marked as a favorite
-        isfav_TVess['season'][item['SeasonId']] = get_additional_item_info(server_url, user_key, item['SeasonId'], auth_key)['UserData']['IsFavorite']
+        isfav_TVessn['season'][item['SeasonId']] = get_additional_item_info(server_url, user_key, item['SeasonId'], auth_key)['UserData']['IsFavorite']
     #Check if series' favorite value already exists in dictionary
-    if not item['SeriesId'] in isfav_TVess['series']:
+    if not item['SeriesId'] in isfav_TVessn['series']:
         #Store if the series is marked as a favorite
-        isfav_TVess['series'][item['SeriesId']] = get_additional_item_info(server_url, user_key, item['SeriesId'], auth_key)['UserData']['IsFavorite']
+        isfav_TVessn['series'][item['SeriesId']] = get_additional_item_info(server_url, user_key, item['SeriesId'], auth_key)['UserData']['IsFavorite']
+    #Check if network's favorite value already exists in dictionary
+    if not item['SeriesStudio'] in isfav_TVessn['network_channel']:
+        #Store if the channel/network/studio is marked as a favorite
+        isfav_TVessn['network_channel'][item['SeriesStudio']] = get_studio_item_info(server_url, user_key, item['SeriesStudio'], auth_key)['UserData']['IsFavorite']
     if bool(cfg.DEBUG):
         #DEBUG
         print('-----------------------------------------------------------')
-        print('Episode is favorite: ' + str(isfav_TVess['episode'][item['Id']]))
-        print(' Season is favorite: ' + str(isfav_TVess['season'][item['SeasonId']]))
-        print(' Series is favorite: ' + str(isfav_TVess['series'][item['SeriesId']]))
+        print('Episode is favorite: ' + str(isfav_TVessn['episode'][item['Id']]))
+        print(' Season is favorite: ' + str(isfav_TVessn['season'][item['SeasonId']]))
+        print(' Series is favorite: ' + str(isfav_TVessn['series'][item['SeriesId']]))
+        print('Network is favorite: ' + str(isfav_TVessn['network_channel'][item['SeriesStudio']]))
 
     #Check if episode, season, or series are a favorite
-    itemisfav_TVess=False
+    itemisfav_TVessn=False
     if (
-       (isfav_TVess['episode'][item['Id']]) or
-       (isfav_TVess['season'][item['SeasonId']]) or
-       (isfav_TVess['series'][item['SeriesId']]) #or
+       (isfav_TVessn['episode'][item['Id']]) or
+       (isfav_TVessn['season'][item['SeasonId']]) or
+       (isfav_TVessn['series'][item['SeriesId']]) or
+       (isfav_TVessn['network_channel'][item['SeriesStudio']]) #or
        ):
-        #Either the episode, season, or series are set as a favorite
-        itemisfav_TVess=True
+        #Either the episode, season, series, or network are set as a favorite
+        itemisfav_TVessn=True
 
-    return(itemisfav_TVess)
+    return(itemisfav_TVessn)
 
 
 #determine if media item is in whitelisted folder
@@ -742,7 +759,7 @@ def get_items(server_url, user_key, auth_key):
     print('Get List Of Played Media:')
     print('-----------------------------------------------------------')
 
-    url=server_url + '/Users/' + user_key  + '/Items?Recursive=true&IsPlayed=true&SortBy=Type,SeriesName,ParentIndexNumber,IndexNumber,Name&SortOrder=Ascending&api_key=' + auth_key
+    url=server_url + '/Users/' + user_key  + '/Items?Recursive=true&IsPlayed=true&SortBy=Type,SeriesName,ParentIndexNumber,IndexNumber,Name&SortOrder=Ascending&fields=SeriesStudio,Studios&api_key=' + auth_key
 
     if bool(cfg.DEBUG):
         #DEBUG
@@ -767,12 +784,10 @@ def get_items(server_url, user_key, auth_key):
     cut_off_date_audio=datetime.now(timezone.utc) - timedelta(cfg.not_played_age_audio)
     deleteItems=[]
 
-    #define empty dictionary for favorited TV Series', Seasons, and Episodes
-    isfav_TVess={'episode':{},'season':{},'series':{}}
+    #define empty dictionary for favorited TV Series', Seasons, Episodes, and Channels/Networks
+    isfav_TVessn={'episode':{},'season':{},'series':{},'network_channel':{}}
     #define empty dictionary for favorited Tracks, Albums, Artists
     isfav_MUSICtaa={'track':{},'album':{},'artist':{}}
-    #define empty dictionary for favorited Track Genres, Album Genres, Artist Genres
-    isfav_MUSICgentaa={'genres_track':{},'genres_album':{},'genres_artist':{}} #Work In Progress...
 
     #Determine if media item is to be deleted or kept
     for item in data['Items']:
@@ -809,7 +824,7 @@ def get_items(server_url, user_key, auth_key):
         #find tv-episode media items ready to delete
         elif ((item['Type'] == 'Episode') and not (cfg.not_played_age_episode == -1)):
             #Get if episode, season, or series is set as favorite
-            itemisfav_TVess=get_isfav_TVess(isfav_TVess, item, server_url, user_key, auth_key)
+            itemisfav_TVessn=get_isfav_TVessn(isfav_TVessn, item, server_url, user_key, auth_key)
             #Get if media item is whitelisted
             item_info=get_additional_item_info(server_url, user_key, item['Id'], auth_key)
             itemIsWhiteListed=get_iswhitelisted(item_info['Path'])
@@ -817,11 +832,11 @@ def get_items(server_url, user_key, auth_key):
                (cfg.not_played_age_episode >= 0) and
                (item['UserData']['PlayCount'] >= 1) and
                (cut_off_date_episode > parse(item['UserData']['LastPlayedDate'])) and
-               (not bool(cfg.keep_favorites_episode) or (not itemisfav_TVess)) and
+               (not bool(cfg.keep_favorites_episode) or (not itemisfav_TVessn)) and
                (not itemIsWhiteListed)
                ):
                 try:
-                    item_details=item['Type'] + ' - ' + item['SeriesName'] + ' - ' + get_season_episode(item['ParentIndexNumber'], item['IndexNumber']) + ' - ' + item['Name'] + ' - ' + get_days_since_played(item['UserData']['LastPlayedDate']) + ' - Favorite: ' + str(itemisfav_TVess) + ' - Whitelisted: ' + str(itemIsWhiteListed) + ' - ' + 'EpisodeID: ' + item['Id']
+                    item_details=item['Type'] + ' - ' + item['SeriesName'] + ' - ' + get_season_episode(item['ParentIndexNumber'], item['IndexNumber']) + ' - ' + item['Name'] + ' - ' + item['SeriesStudio'] + ' - ' + get_days_since_played(item['UserData']['LastPlayedDate']) + ' - Favorite: ' + str(itemisfav_TVessn) + ' - Whitelisted: ' + str(itemIsWhiteListed) + ' - ' + 'EpisodeID: ' + item['Id']
                 except (KeyError):
                     item_details='  ' + item['Type'] + ' - ' + item['Name'] + ' - ' + item['Id']
                     if bool(cfg.DEBUG):
@@ -831,7 +846,7 @@ def get_items(server_url, user_key, auth_key):
                 deleteItems.append(item)
             else:
                 try:
-                    item_details=item['Type'] + ' - ' + item['SeriesName'] + ' - ' + get_season_episode(item['ParentIndexNumber'], item['IndexNumber']) + ' - ' + item['Name'] + ' - ' + get_days_since_played(item['UserData']['LastPlayedDate']) + ' - Favorite: ' + str(itemisfav_TVess) + ' - Whitelisted: ' + str(itemIsWhiteListed) + ' - ' + 'EpisodeID: ' + item['Id']
+                    item_details=item['Type'] + ' - ' + item['SeriesName'] + ' - ' + get_season_episode(item['ParentIndexNumber'], item['IndexNumber']) + ' - ' + item['Name'] + ' - ' + item['SeriesStudio'] + ' - ' + get_days_since_played(item['UserData']['LastPlayedDate']) + ' - Favorite: ' + str(itemisfav_TVessn) + ' - Whitelisted: ' + str(itemIsWhiteListed) + ' - ' + 'EpisodeID: ' + item['Id']
                 except (KeyError):
                     item_details='  ' + item['Type'] + ' - ' + item['Name'] + ' - ' + item['Id']
                     if bool(cfg.DEBUG):
@@ -950,8 +965,8 @@ def get_items(server_url, user_key, auth_key):
     if bool(cfg.DEBUG):
         print('-----------------------------------------------------------')
         print('')
-        print('isfav_TVess: ')
-        print(isfav_TVess)
+        print('isfav_TVessn: ')
+        print(isfav_TVessn)
         print('')
         print('isfav_MUSICtaa: ')
         print(isfav_MUSICtaa)
@@ -1024,7 +1039,7 @@ def cfgCheck():
         (test <= 365000000))
        ):
         errorfound=True
-        error_found_in_media_cleaner_config_py+='not_played_age_movie must be an integer; valid range -1 thru 365000000\n'
+        error_found_in_media_cleaner_config_py+='TypeError: not_played_age_movie must be an integer; valid range -1 thru 365000000\n'
 
     test=cfg.not_played_age_episode
     if (
@@ -1107,25 +1122,27 @@ def cfgCheck():
         errorfound=True
         error_found_in_media_cleaner_config_py+='TypeError: keep_favorites_audio must be an integer; valid values 0 and 1\n'
 
-    test=cfg.keep_favorites_audio_advanced
+    test=cfg.keep_favorites_advanced
     if (
         not ((type(test) is str) and
         (int(test, 2) >= 0) and
-        (int(test, 2) <= 31) and
-        (len(test) == 5))
+        (int(test, 2) <= 255) and
+        (len(test) >=2) and
+        (len(test) <= 8))
        ):
         errorfound=True
-        error_found_in_media_cleaner_config_py+='TypeError: keep_favorites_audio_advanced must be a 5-digit binary string; valid range binary - 00000 thru 11111 (decimal - 0 thru 31)\n'
+        error_found_in_media_cleaner_config_py+='TypeError: keep_favorites_advanced should be an 8-digit binary string; valid range binary - 00000000 thru 11111111 (decimal - 0 thru 255)\n'
 
-    test=cfg.keep_favorites_audio_advanced_any
+    test=cfg.keep_favorites_advanced_any
     if (
         not ((type(test) is str) and
         (int(test, 2) >= 0) and
-        (int(test, 2) <= 31) and
-        (len(test) == 5))
+        (int(test, 2) <= 255) and
+        (len(test) >= 2) and
+        (len(test) <= 8))
        ):
         errorfound=True
-        error_found_in_media_cleaner_config_py+='TypeError: keep_favorites_audio_advanced_any must be a 5-digit binary string; valid range binary - 00000 thru 11111 (decimal - 0 thru 31)\n'
+        error_found_in_media_cleaner_config_py+='TypeError: keep_favorites_advanced_any should be an 8-digit binary string; valid range binary - 00000000 thru 11111111 (decimal - 0 thru 255)\n'
 
     test=cfg.whitelisted_library_folders
     if (
@@ -1188,6 +1205,7 @@ def cfgCheck():
         error_found_in_media_cleaner_config_py+='TypeError: DEBUG must be an integer; valid values 0 and 1'
 
     if (errorfound):
+        error_found_in_media_cleaner_config_py=error_found_in_media_cleaner_config_py.replace('TypeError: ','',1)
         raise TypeError(error_found_in_media_cleaner_config_py)
 
 ############# START OF SCRIPT #############
@@ -1213,8 +1231,8 @@ try:
         not hasattr(cfg, 'keep_favorites_video') or
         not hasattr(cfg, 'keep_favorites_trailer') or
         not hasattr(cfg, 'keep_favorites_audio') or
-        not hasattr(cfg, 'keep_favorites_audio_advanced') or
-        not hasattr(cfg, 'keep_favorites_audio_advanced_any') or
+        not hasattr(cfg, 'keep_favorites_advanced') or
+        not hasattr(cfg, 'keep_favorites_advanced_any') or
         not hasattr(cfg, 'remove_files') or
         not hasattr(cfg, 'whitelisted_library_folders') or
         not hasattr(cfg, 'server_brand') or
@@ -1318,12 +1336,12 @@ try:
         if not hasattr(cfg, 'keep_favorites_audio'):
             print('keep_favorites_audio=1')
             setattr(cfg, 'keep_favorites_audio', 1)
-        if not hasattr(cfg, 'keep_favorites_audio_advanced'):
-            print('keep_favorites_audio_advanced=00001')
-            setattr(cfg, 'keep_favorites_audio_advanced', '00001')
-        if not hasattr(cfg, 'keep_favorites_audio_advanced_any'):
-            print('keep_favorites_audio_advanced_any=00000')
-            setattr(cfg, 'keep_favorites_audio_advanced_any', '00000')
+        if not hasattr(cfg, 'keep_favorites_advanced'):
+            print('keep_favorites_advanced=00000001')
+            setattr(cfg, 'keep_favorites_advanced', '00000001')
+        if not hasattr(cfg, 'keep_favorites_advanced_any'):
+            print('keep_favorites_advanced_any=00000000')
+            setattr(cfg, 'keep_favorites_advanced_any', '00000000')
 
         if not hasattr(cfg, 'whitelisted_library_folders'):
             print('whitelisted_library_folders=\'\'')

--- a/media_cleaner.py
+++ b/media_cleaner.py
@@ -123,7 +123,7 @@ def get_admin_password():
     return(password)
 
 
-#used of hashed password to be removed in future
+#use of hashed password removed
 #hash admin password
 #def get_admin_password_sha1(password):
 #    #password_sha1=password #input('Enter admin password (password will be hashed in config file): ')
@@ -167,10 +167,10 @@ def generate_config():
 
     config_file=''
     config_file += "#----------------------------------------------------------#\n"
-    config_file += "# 0-365000000 - Delete media type once it has been played x days ago\n"
-    config_file += "# -1 : to disable managing specified media type\n"
+    config_file += "# Delete media type once it has been played x days ago\n"
+    config_file += "#   0-365000000 - number of days to wait before deleting played media\n"
+    config_file += "#  -1 : to disable managing specified media type\n"
     config_file += "# (-1 : default)\n"
-    config_file += "# Audio media is a work in progress...\n"
     config_file += "#----------------------------------------------------------#\n"
     config_file += "not_played_age_movie=" + not_played_age_movie + "\n"
     config_file += "not_played_age_episode=" + not_played_age_episode + "\n"
@@ -183,10 +183,10 @@ def generate_config():
     config_file += "#----------------------------------------------------------#\n"
     config_file += "# Favoriting a series or season will treat all child episodes as if they are favorites\n"
     config_file += "# Favoriting an artist, album-artist, or album will treat all child tracks as if they are favorites\n"
-    config_file += "# 0 - Ok to delete movie played not_played_age_movie=x days ago\n"
-    config_file += "# 1 - Do no delete movie played not_played_age_movie=x days ago\n"
+    config_file += "#  0 : ok to delete movie played not_played_age_movie=x days ago\n"
+    config_file += "#  1 : do no delete movie played not_played_age_movie=x days ago\n"
+    config_file += "# (1 : default)\n"
     config_file += "# Same applies for other media types (episodes, trailers, etc...)\n"
-    config_file += "# (1 - default)\n"
     config_file += "#----------------------------------------------------------#\n"
     config_file += "keep_favorites_movie=1\n"
     config_file += "keep_favorites_episode=1\n"
@@ -194,6 +194,36 @@ def generate_config():
     config_file += "keep_favorites_trailer=1\n"
     config_file += "keep_favorites_audio=1\n"
     #config_file += "keep_favorites_tvchannel=1\n"
+    #config_file += "#----------------------------------------------------------#\n"
+    config_file += "\n"
+    config_file += "#----------------------------------------------------------#\n"
+    config_file += "# Advanced audio favorites configuration bitmask\n"
+    config_file += "#     Requires 'keep_favorites_audio=1'\n"
+    config_file += "#  xxxxA - keep audio tracks based on if the FIRST artist listed in the track's 'artist' metadata is favorited\n"
+    config_file += "#  xxxBx - keep audio tracks based on if the FIRST artist listed in the tracks's 'album artist' metadata is favorited\n"
+    config_file += "#  xxCxx - genre work in progress...\n"
+    config_file += "#  xDxxx - genre work in progress...\n"
+    config_file += "#  Exxxx - genre work in progress...\n"
+    config_file += "#  0 bit - disabled\n"
+    config_file += "#  1 bit - enabled\n"
+    config_file += "# (00001 - default)\n"
+    config_file += "#----------------------------------------------------------#\n"
+    config_file += "keep_favorites_audio_advanced='00001'\n"
+    #config_file += "#----------------------------------------------------------#\n"
+    config_file += "\n"
+    config_file += "#----------------------------------------------------------#\n"
+    config_file += "# Advanced audio favorites any configuration bitmask\n"
+    config_file += "#     Requires matching bit in 'keep_favorites_audio_advanced' bitmask is enabled\n"
+    config_file += "#  xxxxa - xxxxA must be enabled above; will use ANY artists listed in the track's 'artist' metadata\n"
+    config_file += "#  xxxbx - xxxBx must be enabled above; will use ANY artists listed in the track's 'album artist' metadata\n"
+    config_file += "#  xxcxx - genre work in progress...\n"
+    config_file += "#  xdxxx - genre work in progress...\n"
+    config_file += "#  exxxx - genre work in progress...\n"
+    config_file += "#  0 bit - disabled\n"
+    config_file += "#  1 bit - enabled\n"
+    config_file += "# (00000 - default)\n"
+    config_file += "#----------------------------------------------------------#\n"
+    config_file += "keep_favorites_audio_advanced_any='00000'\n"
     #config_file += "#----------------------------------------------------------#\n"
     config_file += "\n"
     config_file += "#----------------------------------------------------------#\n"
@@ -279,7 +309,7 @@ def get_auth_key(server_url, username, password):
     DATA = convert2json(values)
     DATA = DATA.encode('utf-8')
 
-    headers = {'X-Emby-Authorization' : 'Emby UserId="'+ username  +'", Client="media_cleaner", Device="media_cleaner", DeviceId="media_cleaner", Version="0.3", Token=""', 'Content-Type' : 'application/json'}
+    headers = {'X-Emby-Authorization' : 'Emby UserId="'+ username  +'", Client="media_cleaner", Device="media_cleaner", DeviceId="media_cleaner", Version="0.4", Token=""', 'Content-Type' : 'application/json'}
 
     req = request.Request(url=server_url + '/Users/AuthenticateByName', data=DATA, method='POST', headers=headers)
 
@@ -511,12 +541,128 @@ def get_additional_item_info(server_url, user_key, itemId, auth_key):
     return(itemInfo)
 
 
-#determine if track, album or artist is set to favorite
-#def get_isfav_MUSICtaa(isfav_MUSICtaa, item, server_url, user_key, auth_key):
-    #work in progress
+#determinne if track genre, album genre, or artist genre are set to favorite
+def get_isfav_MUSICgentaa(isfav_MUSICgentaa, item, server_url, user_key, auth_key):
+    #Work In Progress...
 
+    #Set bitmasks
+    adv_settings=int(cfg.keep_favorites_audio_advanced, 2)
+    adv_all=int(cfg.keep_favorites_audio_advanced_any, 2)
+    trackgenre_mask=int('00100', 2)
+    albumgenre_mask=int('01000', 2)
+    artistgenre_mask=int('10000', 2)
+    trackgenre_any_mask=trackgenre
+    albumgenre_any_mask=albumgenre
+    artistgenre_any_mask=artistgenre
 
-#determine if episode, season, or series is set to favorite
+    return()
+
+#determine if track, album, or artist are set to favorite
+def get_isfav_MUSICtaa(isfav_MUSICtaa, item, server_url, user_key, auth_key):
+    #Set bitmasks
+    adv_settings=int(cfg.keep_favorites_audio_advanced, 2)
+    adv_all=int(cfg.keep_favorites_audio_advanced_any, 2)
+    trackartist_mask=int('00001', 2)
+    albumartist_mask=int('00010', 2)
+    trackartist_any_mask=trackartist_mask
+    albumartist_any_mask=albumartist_mask
+
+    item_info = get_additional_item_info(server_url, user_key, item['Id'], auth_key)
+    #Check if track's favorite value already exists in dictionary
+    if not item['Id'] in isfav_MUSICtaa['track']:
+        #Store if this track is marked as a favorite
+        isfav_MUSICtaa['track'][item['Id']] = item_info['UserData']['IsFavorite']
+
+    item_info = get_additional_item_info(server_url, user_key, item['AlbumId'], auth_key)
+    #Check if album's favorite value already exists in dictionary
+    if not item['AlbumId'] in isfav_MUSICtaa['album']:
+        #Store if the album is marked as a favorite
+        isfav_MUSICtaa['album'][item['AlbumId']] = item_info['UserData']['IsFavorite']
+
+    #Check if bitmask for favorites by track artist is enabled
+    if (adv_settings & trackartist_mask):
+        #Check if bitmask for any or first track artist is enabled
+        if not (adv_all & trackartist_any_mask):
+            item_info = get_additional_item_info(server_url, user_key, item['ArtistItems'][0]['Id'], auth_key)
+            #Check if artist's favorite value already exists in dictionary
+            if not item['ArtistItems'][0]['Id'] in isfav_MUSICtaa['artist']:
+                #Store if first track artist is marked as favorite
+                isfav_MUSICtaa['artist'][item['ArtistItems'][0]['Id']] = item_info['UserData']['IsFavorite']
+        else:
+            for artist in range(len(item['ArtistItems'])):
+                item_info = get_additional_item_info(server_url, user_key, item['ArtistItems'][artist]['Id'], auth_key)
+                #Check if artist's favorite value already exists in dictionary
+                if not item['ArtistItems'][artist]['Id'] in isfav_MUSICtaa['artist']:
+                    #Store if any track artist is marked as a favorite
+                    isfav_MUSICtaa['artist'][item['ArtistItems'][artist]['Id']] = item_info['UserData']['IsFavorite']
+
+    #Check if bitmask for favotires by album artist is enabled
+    if (adv_settings & albumartist_mask):
+        #Check if bitmask for any or first album artist is enabled
+        if not (adv_all & albumartist_any_mask):
+            item_info = get_additional_item_info(server_url, user_key, item['AlbumArtists'][0]['Id'], auth_key)
+            #Check if artist's favorite value already exists in dictionary
+            if not item['AlbumArtists'][0]['Id'] in isfav_MUSICtaa['artist']:
+                #Store if first album artist is marked as favorite
+                isfav_MUSICtaa['artist'][item['AlbumArtists'][0]['Id']] = item_info['UserData']['IsFavorite']
+        else:
+            for albumartist in range(len(item['AlbumArtists'])):
+                item_info = get_additional_item_info(server_url, user_key, item['AlbumArtists'][albumartist]['Id'], auth_key)
+                #Check if artist's favorite value already exists in dictionary
+                if not item['AlbumArtists'][albumartist]['Id'] in isfav_MUSICtaa['artist']:
+                    #Store if any album artist is marked as a favorite
+                    isfav_MUSICtaa['artist'][item['AlbumArtists'][albumartist]['Id']] = item_info['UserData']['IsFavorite']
+
+    if bool(cfg.DEBUG):
+        #DEBUG
+        print('-----------------------------------------------------------')
+        print('  Track is favorite: ' + str(isfav_MUSICtaa['track'][item['Id']]))
+        print('  Album is favorite: ' + str(isfav_MUSICtaa['album'][item['AlbumId']]))
+        if (adv_settings & trackartist_mask):
+            for artist in range(len(item['ArtistItems'])):
+                print('  ' + item['ArtistItems'][artist]['Name'] + ' is favorite: ' + str(isfav_MUSICtaa['artist'][item['ArtistItems'][artist]['Id']]))
+        if (adv_settings & albumartist_mask):
+            for albumartist in range(len(item['AlbumArtists'])):
+                print('  ' + item['AlbumArtists'][artist]['Name'] + ' is favorite: ' + str(isfav_MUSICtaa['artist'][item['AlbumArtists'][albumartist]['Id']]))
+
+    #Check if track or album was stored as a favorite
+    itemisfav_MUSICtrackalbum=False
+    if (
+       (isfav_MUSICtaa['track'][item['Id']]) or
+       (isfav_MUSICtaa['album'][item['AlbumId']])
+       ):
+        #Either the track or album was stored as a favorite
+        itemisfav_MUSICtrackalbum=True
+
+    #Check if track artist was stored as a favorite
+    itemisfav_MUSICartist=False
+    if (adv_settings & trackartist_mask):
+        #Check if any track artist was stored as a favorite
+        for artist in range(len(item['ArtistItems'])):
+            if (isfav_MUSICtaa['artist'][item['ArtistItems'][artist]['Id']]):
+                itemisfav_MUSICartist=True
+
+    #Check if album artist was stored as a favorite
+    itemisfav_MUSICalbumartist=False
+    if (adv_settings & albumartist_mask):
+        #Check if any album artist was stored as a favorite
+        for albumartist in range(len(item['AlbumArtists'])):
+            if (isfav_MUSICtaa['artist'][item['AlbumArtists'][albumartist]['Id']]):
+                itemisfav_MUSICalubmartist=True
+
+    #Check if track, album, or artist are a favorite
+    itemisfav_MUSICtaa=False
+    if (
+       (itemisfav_MUSICtrackalbum) or
+       (itemisfav_MUSICartist) or
+       (itemisfav_MUSICalbumartist)
+       ):
+        #Either the track, album, or artist(s) are set as a favorite
+        itemisfav_MUSICtaa=True
+
+    return(itemisfav_MUSICtaa)
+
+#determine if episode, season, or series are set to favorite
 def get_isfav_TVess(isfav_TVess, item, server_url, user_key, auth_key):
     #Check if episode's favorite value already exists in dictionary
     if not item['Id'] in isfav_TVess['episode']:
@@ -537,17 +683,15 @@ def get_isfav_TVess(isfav_TVess, item, server_url, user_key, auth_key):
         print(' Season is favorite: ' + str(isfav_TVess['season'][item['SeasonId']]))
         print(' Series is favorite: ' + str(isfav_TVess['series'][item['SeriesId']]))
 
-    #Check if episode, season, or series is a favorite
+    #Check if episode, season, or series are a favorite
+    itemisfav_TVess=False
     if (
        (isfav_TVess['episode'][item['Id']]) or
        (isfav_TVess['season'][item['SeasonId']]) or
        (isfav_TVess['series'][item['SeriesId']]) #or
        ):
-        #Either the episode, season, or series is set as a favorite
+        #Either the episode, season, or series are set as a favorite
         itemisfav_TVess=True
-    else:
-        #Neither the episode, season, or series is set as a favorite
-        itemisfav_TVess=False
 
     return(itemisfav_TVess)
 
@@ -558,8 +702,8 @@ def get_iswhitelisted(itemPath):
     whitelist=cfg.whitelisted_library_folders
     whitelistentries=whitelist.split(',')
 
-    item_is_whitelisted=False
     #determine if media item's path matches one of the whitelist folders
+    item_is_whitelisted=False
     for path in whitelistentries:
         if not (path == ''):
             if (itemPath.startswith(path)):
@@ -618,17 +762,18 @@ def get_items(server_url, user_key, auth_key):
 
     #define empty dictionary for favorited TV Series', Seasons, and Episodes
     isfav_TVess={'episode':{},'season':{},'series':{}}
-    #define empty dictionary for favorited Artists', Albums, and Audio-Tracks
+    #define empty dictionary for favorited Tracks, Albums, Artists
     isfav_MUSICtaa={'track':{},'album':{},'artist':{}}
+    #define empty dictionary for favorited Track Genres, Album Genres, Artist Genres
+    isfav_MUSICgentaa={'genres_track':{},'genres_album':{},'genres_artist':{}} #Work In Progress...
 
     #Determine if media item is to be deleted or kept
     for item in data['Items']:
-        #Get if media item is whitelisted
-        item_info=get_additional_item_info(server_url, user_key, item['Id'], auth_key)
-        itemIsWhiteListed=get_iswhitelisted(item_info['Path'])
-
         #find movie media items ready to delete
-        if (item['Type'] == 'Movie'):
+        if ((item['Type'] == 'Movie') and not (cfg.not_played_age_movie == -1)):
+            #Get if media item is whitelisted
+            item_info=get_additional_item_info(server_url, user_key, item['Id'], auth_key)
+            itemIsWhiteListed=get_iswhitelisted(item_info['Path'])
             if (
                (cfg.not_played_age_movie >= 0) and
                (item['UserData']['PlayCount'] >= 1) and
@@ -655,9 +800,12 @@ def get_items(server_url, user_key, auth_key):
                         print('\nError encountered - Keep Movie: \n' + str(item))
                 print(':[KEEPING] - ' + item_details)
         #find tv-episode media items ready to delete
-        elif (item['Type'] == 'Episode'):
+        elif ((item['Type'] == 'Episode') and not (cfg.not_played_age_episode == -1)):
             #Get if episode, season, or series is set as favorite
             itemisfav_TVess=get_isfav_TVess(isfav_TVess, item, server_url, user_key, auth_key)
+            #Get if media item is whitelisted
+            item_info=get_additional_item_info(server_url, user_key, item['Id'], auth_key)
+            itemIsWhiteListed=get_iswhitelisted(item_info['Path'])
             if (
                (cfg.not_played_age_episode >= 0) and
                (item['UserData']['PlayCount'] >= 1) and
@@ -684,7 +832,10 @@ def get_items(server_url, user_key, auth_key):
                         print('\nError encountered - Keep Episode: \n' + str(item))
                 print(':[KEEPING] - ' + item_details)
         #find video media items ready to delete
-        elif (item['Type'] == 'Video'):
+        elif ((item['Type'] == 'Video') and not (cfg.not_played_age_video == -1)):
+            #Get if media item is whitelisted
+            item_info=get_additional_item_info(server_url, user_key, item['Id'], auth_key)
+            itemIsWhiteListed=get_iswhitelisted(item_info['Path'])
             if (
                (item['Type'] == 'Video') and
                (cfg.not_played_age_video >= 0) and
@@ -712,7 +863,10 @@ def get_items(server_url, user_key, auth_key):
                         print('\nError encountered - Keep Video: \n' + str(item))
                 print(':[KEEPING] - ' + item_details)
         #find trailer media items ready to delete
-        elif (item['Type'] == 'Trailer'):
+        elif ((item['Type'] == 'Trailer') and not (cfg.not_played_age_trailer == -1)):
+            #Get if media item is whitelisted
+            item_info=get_additional_item_info(server_url, user_key, item['Id'], auth_key)
+            itemIsWhiteListed=get_iswhitelisted(item_info['Path'])
             if (
                (cfg.not_played_age_trailer >= 0) and
                (item['UserData']['PlayCount'] >= 1) and
@@ -739,18 +893,23 @@ def get_items(server_url, user_key, auth_key):
                         print('\nError encountered - Keep Trailer: \n' + str(item))
                 print(':[KEEPING] - ' + item_details)
         #find audio media items ready to delete
-        elif (item['Type'] == 'Audio'):
+        elif ((item['Type'] == 'Audio') and not (cfg.not_played_age_audio == -1)):
+            #Get if track, album, or artist is set as favorite
+            itemisfav_MUSICtaa=get_isfav_MUSICtaa(isfav_MUSICtaa, item, server_url, user_key, auth_key)
+            #Get if media item is whitelisted
+            item_info=get_additional_item_info(server_url, user_key, item['Id'], auth_key)
+            itemIsWhiteListed=get_iswhitelisted(item_info['Path'])
             if (
                (cfg.not_played_age_audio >= 0) and
                (item['UserData']['PlayCount'] >= 1) and
                (cut_off_date_audio > parse(item['UserData']['LastPlayedDate'])) and
-               (not bool(cfg.keep_favorites_audio) or not item['UserData']['IsFavorite']) and
+               (not bool(cfg.keep_favorites_audio) or (not itemisfav_MUSICtaa)) and
                (not itemIsWhiteListed)
                ):
                 try:
-                    item_details='  ' + item['Type'] + ' - ' + item['Name'] + ' - Album: ' + item['Album'] + ' - Artist: ' + item['Artists'][0] + ' - ' + get_days_since_played(item['UserData']['LastPlayedDate']) + ' -  Favorite: ' + str(item['UserData']['IsFavorite']) + ' - Whitelisted: ' + str(itemIsWhiteListed) + ' - ' + 'TrackID: ' + item['Id']
+                    item_details='  ' + item['Type'] + ' - Track: ' + item['Name'] + ' - Album: ' + item['Album'] + ' - Artist: ' + item['Artists'][0] + ' - ' + get_days_since_played(item['UserData']['LastPlayedDate']) + ' -  Favorite: ' + str(itemisfav_MUSICtaa) + ' - Whitelisted: ' + str(itemIsWhiteListed) + ' - ' + 'TrackID: ' + item['Id']
                 except (KeyError):
-                    item_details='  ' + item['Type'] + ' - ' + item['Name'] + ' - ' + item['Id']
+                    item_details='  ' + item['Type'] + ' - Track: ' + item['Name'] + ' - ' + item['Id']
                     if bool(cfg.DEBUG):
                         #DEBUG
                         print('\nError encountered - Delete Audio: \n' + str(item))
@@ -758,9 +917,9 @@ def get_items(server_url, user_key, auth_key):
                 deleteItems.append(item)
             else:
                 try:
-                    item_details='  ' + item['Type'] + ' - ' + item['Name'] + ' - Album: ' + item['Album'] + ' - Artist: ' + item['Artists'][0] + ' - ' + get_days_since_played(item['UserData']['LastPlayedDate']) + ' - Favorite: ' + str(item['UserData']['IsFavorite']) + ' - Whitelisted: ' + str(itemIsWhiteListed) + ' - ' + 'TrackID: ' + item['Id']
+                    item_details='  ' + item['Type'] + ' - Track: ' + item['Name'] + ' - Album: ' + item['Album'] + ' - Artist: ' + item['Artists'][0] + ' - ' + get_days_since_played(item['UserData']['LastPlayedDate']) + ' - Favorite: ' + str(itemisfav_MUSICtaa) + ' - Whitelisted: ' + str(itemIsWhiteListed) + ' - ' + 'TrackID: ' + item['Id']
                 except (KeyError):
-                    item_details='  ' + item['Type'] + ' - ' + item['Name'] + ' - ' + item['Id']
+                    item_details='  ' + item['Type'] + ' - Track: ' + item['Name'] + ' - ' + item['Id']
                     if bool(cfg.DEBUG):
                         #DEBUG
                         print('\nError encountered - Keep Audio: \n' + str(item))
@@ -846,7 +1005,7 @@ def list_delete_items(deleteItems):
 
 
 #Check select config variables are an expected value
-def cfgVarValCheck():
+def cfgCheck():
 
     errorfound=False
     error_found_in_media_cleaner_config_py=''
@@ -941,6 +1100,26 @@ def cfgVarValCheck():
         errorfound=True
         error_found_in_media_cleaner_config_py+='TypeError: keep_favorites_audio must be an integer; valid values 0 and 1\n'
 
+    test=cfg.keep_favorites_audio_advanced
+    if (
+        not ((type(test) is str) and
+        (int(test, 2) >= 0) and
+        (int(test, 2) <= 31) and
+        (len(test) == 5))
+       ):
+        errorfound=True
+        error_found_in_media_cleaner_config_py+='TypeError: keep_favorites_audio_advanced must be a 5-digit binary string; valid range binary - 00000 thru 11111 (decimal - 0 thru 31)\n'
+
+    test=cfg.keep_favorites_audio_advanced_any
+    if (
+        not ((type(test) is str) and
+        (int(test, 2) >= 0) and
+        (int(test, 2) <= 31) and
+        (len(test) == 5))
+       ):
+        errorfound=True
+        error_found_in_media_cleaner_config_py+='TypeError: keep_favorites_audio_advanced_any must be a 5-digit binary string; valid range binary - 00000 thru 11111 (decimal - 0 thru 31)\n'
+
     test=cfg.whitelisted_library_folders
     if (
         not (type(test) is str)
@@ -1027,6 +1206,8 @@ try:
         not hasattr(cfg, 'keep_favorites_video') or
         not hasattr(cfg, 'keep_favorites_trailer') or
         not hasattr(cfg, 'keep_favorites_audio') or
+        not hasattr(cfg, 'keep_favorites_audio_advanced') or
+        not hasattr(cfg, 'keep_favorites_audio_advanced_any') or
         not hasattr(cfg, 'remove_files') or
         not hasattr(cfg, 'whitelisted_library_folders') or
         not hasattr(cfg, 'server_brand') or
@@ -1130,6 +1311,12 @@ try:
         if not hasattr(cfg, 'keep_favorites_audio'):
             print('keep_favorites_audio=1')
             setattr(cfg, 'keep_favorites_audio', 1)
+        if not hasattr(cfg, 'keep_favorites_audio_advanced'):
+            print('keep_favorites_audio_advanced=00001')
+            setattr(cfg, 'keep_favorites_audio_advanced', '00001')
+        if not hasattr(cfg, 'keep_favorites_audio_advanced_any'):
+            print('keep_favorites_audio_advanced_any=00000')
+            setattr(cfg, 'keep_favorites_audio_advanced_any', '00000')
 
         if not hasattr(cfg, 'whitelisted_library_folders'):
             print('whitelisted_library_folders=\'\'')
@@ -1173,7 +1360,7 @@ except (AttributeError, ModuleNotFoundError):
     exit(0)
 
 #check config values are what we expect them to be
-cfgVarValCheck()
+cfgCheck()
 #find media items to be deleted
 deleteItems=get_items(cfg.server_url, cfg.user_key, cfg.access_token)
 #list and delete found media items

--- a/media_cleaner.py
+++ b/media_cleaner.py
@@ -242,6 +242,16 @@ def generate_config():
     #config_file += "#----------------------------------------------------------#\n"
     config_file += "\n"
     config_file += "#------------DO NOT MODIFY BELOW---------------------------#\n"
+    config_file += "\n"
+    config_file += "#----------------------------------------------------------#\n"
+    config_file += "# Server branding chosen during setup\n"
+    config_file += "#  0 - 'emby'\n"
+    config_file += "#  1 - 'jellyfin'\n"
+    config_file += "# Server URL created during setup\n"
+    config_file += "# Admin username chosen during setup\n"
+    config_file += "# Access token requested from server during setup\n"
+    config_file += "# User key of account to monitor played media chosen during setup\n"
+    config_file += "#----------------------------------------------------------#\n"
     config_file += "server_brand='" + server_brand + "'\n"
     config_file += "server_url='" + server_url + "'\n"
     config_file += "admin_username='" + username + "'\n"
@@ -359,11 +369,11 @@ def list_users(server_url, auth_key):
                 if ((user_number_int >= 0) and (user_number_int < i)):
                     valid_user=True
                 else:
-                    print('\nInvalid number. Try again.\n')
+                    print('\nInvalid value. Try again.\n')
             else:
-                print('\nInvalid number. Try again.\n')
+                print('\nInvalid value. Try again.\n')
         except:
-            print('\nInvalid number. Try again.\n')
+            print('\nInvalid value. Try again.\n')
 
     userID=data[user_number_int]['Id']
     return(userID)
@@ -438,11 +448,11 @@ def list_library_folders(server_url, auth_key):
                         #print('selected library folders')
                         #print(libraryfolders_set)
                     else:
-                        print('\nInvalid number. Try again.\n')
+                        print('\nInvalid value. Try again.\n')
                 else:
-                    print('\nInvalid number. Try again.\n')
+                    print('\nInvalid value. Try again.\n')
         except:
-            print('\nInvalid number. Try again.\n')
+            print('\nInvalid value. Try again.\n')
 
     if (libraryfolders_set == set()):
         return('')
@@ -715,10 +725,7 @@ def get_iswhitelisted(itemPath):
                     print(path + ' : ' + itemPath)
 
                 return(item_is_whitelisted)
-            else:
-                item_is_whitelisted=False
-        else:
-            item_is_whitelisted=False
+
     return(item_is_whitelisted)
 
 


### PR DESCRIPTION
Script will now "clean" music libraries

Default behavior:
    -Keep tracks that are set to favorite
    -Keep child tracks of albums set to favorite
    -Keep tracks by favorited artist (will use only the first artists listed in its artist metadata)

Audio can also be configured to:
    -Keep tracks that have any favorite artist in their metadata (will use all artists listed in its artist metadata)
    -Keep child tracks of albums that have a favorite artist in their metadata (will use only the first artists listed in albums metadata)
    -Keep child tracks of albums that have any favorite artist in their metadata (will use all artists listed in albums metadata)

Work in progress... Genre based favorites