### PR TITLE
Cache url responses in a Dictionary

### DIFF
--- a/mumc.py
+++ b/mumc.py
@@ -17,6 +17,7 @@ from collections import defaultdict
 from datetime import datetime,timedelta,timezone
 from mumc_config_defaults import get_default_config_values
 
+cache = dict()
 
 #Get the current script version
 def get_script_version():
@@ -74,8 +75,14 @@ def does_index_exist(item, indexvalue):
     return(True)
 
 
-#send url request
 def requestURL(url, debugBool, reqeustDebugMessage, retries):
+    if (url not in cache):
+        cache[url] = requestURLNotCached(url, debugBool, reqeustDebugMessage, retries)
+
+    return (cache[url])
+
+#send url request
+def requestURLNotCached(url, debugBool, reqeustDebugMessage, retries):
 
     if (debugBool):
         #Double newline for better debug file readablilty


### PR DESCRIPTION
Eliminates duplicate API calls

Improves performance on my system with ~5800 episodes.  API hits **reduced from 14087 to 993**

Fixes #45 

Cumulative time down from 1073 seconds to 169 seconds.

```
   Ordered by: cumulative time
   List reduced from 1170 to 41 due to restriction <'mumc'>

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
        1    0.002    0.002  169.212  169.212 /config/mumc.py:1(<module>)
        1    0.677    0.677  167.812  167.812 /config/mumc.py:4399(get_media_items)
    14087    0.104    0.000  114.358    0.008 /config/mumc.py:78(requestURL)
      993    0.074    0.000  114.254    0.115 /config/mumc.py:85(requestURLNotCached)
      286    0.002    0.000   59.222    0.207 /config/mumc.py:161(api_query_handler)
     6899    0.193    0.000   55.319    0.008 /config/mumc.py:2950(get_isEPISODE_Fav)
    13798    0.114    0.000   55.119    0.004 /config/mumc.py:2487(get_ADDITIONAL_itemInfo)
    14036    0.332    0.000   37.662    0.003 /config/mumc.py:1880(get_days_since_played)
     7018    0.037    0.000   14.344    0.002 /config/mumc.py:1925(get_days_since_created)
        1    1.684    1.684    8.640    8.640 /config/mumc.py:3945(get_iswhitelist_ByMultiUser)
  1198395    4.891    0.000    6.950    0.000 /config/mumc.py:2291(get_isItemMatching)
      176    0.004    0.000    1.155    0.007 /config/mumc.py:2070(getChildren_favoritedMediaItems)
        1    0.000    0.000    0.430    0.430 /config/mumc.py:4043(get_isplaycount_MetByAllUsers)
        1    0.429    0.429    0.430    0.430 /config/mumc.py:3995(get_isblacktagged_watchedByAllUsers)
     7018    0.109    0.000    0.292    0.000 /config/mumc.py:2365(get_isItemWhitelisted)
    14036    0.108    0.000    0.180    0.000 /config/mumc.py:2329(get_doesItemStartWith)
        1    0.000    0.000    0.116    0.116 /config/mumc.py:31(get_server_version)
    14036    0.060    0.000    0.090    0.000 /config/mumc.py:4048(get_playedStatus)
     7315    0.057    0.000    0.065    0.000 /config/mumc.py:1930(get_season_episode)
     7018    0.010    0.000    0.065    0.000 /config/mumc.py:4113(get_createdStatus)
     7018    0.060    0.000    0.060    0.000 /config/mumc.py:4239(prepare_EPISODEoutput)
        1    0.004    0.004    0.047    0.047 /config/mumc.py:6997(output_itemsToDelete)
        1    0.000    0.000    0.044    0.044 /config/mumc.py:50(get_operating_system_info)
     7357    0.013    0.000    0.038    0.000 /config/mumc.py:4389(print_byType)
      297    0.002    0.000    0.034    0.000 /config/mumc.py:6970(delete_media_item)
     7018    0.013    0.000    0.030    0.000 /config/mumc.py:2039(get_isCreated_FilterValue)
     7111    0.027    0.000    0.027    0.000 /config/mumc.py:2257(get_isItemMonitored)
     7052    0.017    0.000    0.017    0.000 /config/mumc.py:1968(get_isPlayed_FilterValue)
      352    0.003    0.000    0.015    0.000 /config/mumc.py:2149(getChildren_taggedMediaItems)
     7018    0.013    0.000    0.013    0.000 /config/mumc.py:4118(get_deleteStatus)
        1    0.001    0.001    0.002    0.002 /config/mumc.py:7260(cfgCheck)
        2    0.000    0.000    0.001    0.000 /config/mumc.py:476(user_lib_builder)
        2    0.001    0.000    0.001    0.000 /config/mumc.py:7126(cfgCheck_forLibraries)
       34    0.000    0.000    0.000    0.000 /config/mumc.py:2045(get_isPlayedCreated_FilterValue)
       23    0.000    0.000    0.000    0.000 /config/mumc.py:430(isJellyfinServer)
        1    0.000    0.000    0.000    0.000 /config/mumc.py:46(get_python_version)
        1    0.000    0.000    0.000    0.000 /config/mumc.py:1065(change_to_script_directory)
        1    0.000    0.000    0.000    0.000 /config/mumc_config_defaults.py:1(<module>)
        1    0.000    0.000    0.000    0.000 /config/mumc_config.py:1(<module>)
        1    0.000    0.000    0.000    0.000 /config/mumc.py:4383(appendTo_DEBUG_log)
        1    0.000    0.000    0.000    0.000 /config/mumc.py:23(get_script_version)

```