### PR TITLE
Fix for custom config file command line argument TypeError bug

### DIFF
--- a/mumc_modules/mumc_config_import.py
+++ b/mumc_modules/mumc_config_import.py
@@ -51,8 +51,8 @@ def importConfig(init_dict,cmdopt_dict):
             add_to_PATH(cmdopt_dict['altConfigPath'],0)
 
             #check if yaml config
-            if ((getFileExtension(cmdopt_dict['altConfigPath'] + '/' + cmdopt_dict['altConfigFileExt']) == '.yaml') or
-               (getFileExtension(cmdopt_dict['altConfigPath'] + '/' + cmdopt_dict['altConfigFileExt']) == '.yml')):
+            if ((getFileExtension(cmdopt_dict['altConfigPath'] / cmdopt_dict['altConfigFileExt']) == '.yaml') or
+               (getFileExtension(cmdopt_dict['altConfigPath'] / cmdopt_dict['altConfigFileExt']) == '.yml')):
                 #open alternate yaml config
                 with open(cmdopt_dict['altConfigPath'] / cmdopt_dict['altConfigFileExt'], 'r') as mumc_config_yaml:
                     cfg = yaml.safe_load(mumc_config_yaml)

--- a/mumc_modules/mumc_parse_options.py
+++ b/mumc_modules/mumc_parse_options.py
@@ -3,6 +3,7 @@ import os
 from mumc_modules.mumc_console_info import default_helper_menu,print_full_help_menu,missing_config_argument_helper,missing_config_argument_format_helper,alt_config_file_does_not_exists_helper,alt_config_syntax_helper,unknown_command_line_option_helper
 from mumc_modules.mumc_output import getFullPathName,getFileExtension
 from mumc_modules.mumc_console_attributes import console_text_attributes
+from pathlib import Path
 
 #define custom exception
 class CMDOptionIndexError(Exception):
@@ -128,7 +129,7 @@ def parseAltConfigPathFileSyntax(argv,altConfigInfo,cmdOption,moduleExtension,th
                 ((os.path.basename(os.path.splitext(argv[argv.index(cmdOption)+1])[0])).count(".") == 0) and
                 ((os.path.basename(os.path.splitext(argv[argv.index(cmdOption)+1])[0])).count(" ") == 0)):
                 #Get path without file.name
-                altConfigPath=os.path.dirname(argv[argv.index(cmdOption)+1])
+                altConfigPath=Path(os.path.dirname(argv[argv.index(cmdOption)+1]))
                 #Get file without extension
                 altConfigFileNoExt=os.path.basename(os.path.splitext(argv[argv.index(cmdOption)+1])[0])
             else:


### PR DESCRIPTION
Fixing a bug with the custom config file command line argument (-c). Using the -c command line argument (python mumc.py -c "./config/mumc_config.yaml") would trigger a TypeError exception:  unsupported operand type(s) for /: 'str' and 'str'

The custom config file logic was using a combination of string concatenation with "/" between path and filename, as well as the / operator, which is the source of the bug. This is because the / operator is not support on str, but was instead meant to be used on Path objects from pathlib (which works fine with the default non-custom config file logic and init_dict['mumc_path'] because it is a Path object).

The bug fixed by converting the custom config file directory (cmdopt_dict['altConfigPath']) from str to Path and only using the / operator in the custom config file logic.