### PR TITLE
Skip items the server no longer has instead of exiting (fixes #178)

### DIFF
--- a/mumc_modules/mumc_favorited.py
+++ b/mumc_modules/mumc_favorited.py
@@ -160,9 +160,12 @@ def get_isSTUDIONETWORK_Fav(user_info,item,isfav_ITEMstdo_ntwk,favorites_advance
             #Check if bitmask for any or first item genre is enabled
             if (favorites_advanced == 1):
                 #Get studio network's item info
-                studionetwork_item_info = get_ADDITIONAL_itemInfo(user_info,item['Studios'][0]['Id'],'studio_network_info',the_dict)
+                studionetwork_item_info = get_ADDITIONAL_itemInfo(user_info,item['Studios'][0]['Id'],'studio_network_info',the_dict,exitOnError=False)
+                #Studio may reference an itemId the server no longer has; nothing to favorite check (Issue #178)
+                if (studionetwork_item_info == None):
+                    pass
                 #Check if studio-network's favorite value already exists in dictionary
-                if not studionetwork_item_info['Id'] in isfav_ITEMstdo_ntwk:
+                elif not studionetwork_item_info['Id'] in isfav_ITEMstdo_ntwk:
                     if (('UserData' in studionetwork_item_info) and ('IsFavorite' in studionetwork_item_info['UserData'])):
                         #Store if the studio network is marked as a favorite
                         isfav_ITEMstdo_ntwk[studionetwork_item_info['Id']] = studionetwork_item_info['UserData']['IsFavorite']
@@ -175,9 +178,12 @@ def get_isSTUDIONETWORK_Fav(user_info,item,isfav_ITEMstdo_ntwk,favorites_advance
             else:
                 for studios in range(len(item['Studios'])):
                     #Get studio network's item info
-                    studionetwork_item_info = get_ADDITIONAL_itemInfo(user_info,item['Studios'][studios]['Id'],'studio_network_info',the_dict)
+                    studionetwork_item_info = get_ADDITIONAL_itemInfo(user_info,item['Studios'][studios]['Id'],'studio_network_info',the_dict,exitOnError=False)
+                    #Studio may reference an itemId the server no longer has; nothing to favorite check (Issue #178)
+                    if (studionetwork_item_info == None):
+                        pass
                     #Check if studio network's favorite value already exists in dictionary
-                    if not studionetwork_item_info['Id'] in isfav_ITEMstdo_ntwk:
+                    elif not studionetwork_item_info['Id'] in isfav_ITEMstdo_ntwk:
                         if (('UserData' in studionetwork_item_info) and ('IsFavorite' in studionetwork_item_info['UserData'])):
                             #Store if the studio network is marked as a favorite
                             isfav_ITEMstdo_ntwk[studionetwork_item_info['Id']] = studionetwork_item_info['UserData']['IsFavorite']
@@ -410,7 +416,8 @@ def get_isEPISODE_AdvancedFav(the_dict,item,user_info,var_dict):
 
                 if (('Studios' in series_item_info) and (does_index_exist(series_item_info['Studios'],0))):
                     #Get studio network's item info
-                    tvstudionetwork_item_info = get_ADDITIONAL_itemInfo(user_info,series_item_info['Studios'][0]['Id'],'studio_network_info',the_dict)
+                     #exitOnError=False; the None check below already handles a missing item (Issue #178)
+                    tvstudionetwork_item_info = get_ADDITIONAL_itemInfo(user_info,series_item_info['Studios'][0]['Id'],'studio_network_info',the_dict,exitOnError=False)
                 elif ('SeriesStudio' in series_item_info):
                     #Get series studio network's item info
                     tvstudionetwork_item_info = get_STUDIO_itemInfo(series_item_info['SeriesStudio'],the_dict)

--- a/mumc_modules/mumc_item_info.py
+++ b/mumc_modules/mumc_item_info.py
@@ -3,14 +3,16 @@ from mumc_modules.mumc_url import requestURL,build_emby_jellyfin_request_message
 
 
 #get additional item info needed to make a decision about a media item
-def get_ADDITIONAL_itemInfo(user_info,itemId,lookupTopic,the_dict):
+def get_ADDITIONAL_itemInfo(user_info,itemId,lookupTopic,the_dict,exitOnError=True):
     #Get additonal item information
 
     url=the_dict['admin_settings']['server']['url'] + '/Users/' + user_info['user_id']  + '/Items/' + str(itemId) + '?enableImages=False&enableUserData=True&Fields=ParentId,Genres,Tags,RecursiveItemCount,ChildCount,Type,ProviderIds'
 
     req=build_emby_jellyfin_request_message(url,the_dict)
 
-    itemInfo=requestURL(the_dict, req, the_dict['DEBUG'], lookupTopic + '_for_' + str(itemId), the_dict['admin_settings']['api_controls']['attempts'])
+    #exitOnError=False allows callers to handle a missing item (i.e. a stale
+    #reference to an itemId the server no longer has) instead of exiting
+    itemInfo=requestURL(the_dict, req, the_dict['DEBUG'], lookupTopic + '_for_' + str(itemId), the_dict['admin_settings']['api_controls']['attempts'], exitOnError)
 
     return itemInfo
 

--- a/mumc_modules/mumc_tagged.py
+++ b/mumc_modules/mumc_tagged.py
@@ -373,7 +373,8 @@ def get_isEPISODE_Tagged(the_dict,item,user_info,usertags):
 
                 if (('Studios' in series_item_info) and does_index_exist(series_item_info['Studios'],0)):
                     #Get studio network's item info
-                    tvstudionetwork_item_info = get_ADDITIONAL_itemInfo(user_info,series_item_info['Studios'][0]['Id'],'studio_network_info',the_dict)
+                     #exitOnError=False; the None check below already handles a missing item (Issue #178)
+                    tvstudionetwork_item_info = get_ADDITIONAL_itemInfo(user_info,series_item_info['Studios'][0]['Id'],'studio_network_info',the_dict,exitOnError=False)
                 elif ('SeriesStudio' in series_item_info):
                     #Get series studio network's item info
                     tvstudionetwork_item_info = get_STUDIO_itemInfo(series_item_info['SeriesStudio'],the_dict,the_dict)

--- a/mumc_modules/mumc_url.py
+++ b/mumc_modules/mumc_url.py
@@ -361,9 +361,13 @@ def requestURL(the_dict, url='', debugState=0, requestDebugMessage='message unde
                     else:
                         return None
         except HTTPError as err:
-            time.sleep(doubling_delay)
-            #doubling_delay value doubles each time the same API request is resent
-            doubling_delay += doubling_delay
+            #404 Not Found is permanent for this request; retrying cannot change the outcome
+            if (err.code == 404):
+                doubling_delay = (2**retryAttempts)
+            else:
+                time.sleep(doubling_delay)
+                #doubling_delay value doubles each time the same API request is resent
+                doubling_delay += doubling_delay
             if (doubling_delay >= (2**retryAttempts)):
                 print('\nHTTPError: Unable to get information from server during processing of: ' + requestDebugMessage)
                 try:


### PR DESCRIPTION
## What was happening (#178)

When a media item's `Studios[]` array references an itemId the server has since deleted (a stale reference — the reporter verified the item no longer exists in Jellyfin), the `studio_network_info` lookup gets an HTTP 404. `requestURL` then:

1. retried it 4 times with exponential backoff (~15 s wasted — a 404 is permanent for that URL, retrying can't change the outcome), and
2. called `sys.exit(0)`, killing the entire cleanup run mid-scan.

## The fix

- **`mumc_url.py`**: a 404 in the `HTTPError` handler skips the retry/backoff loop and takes the existing failure path immediately. All other HTTP errors retry exactly as before.
- **`mumc_item_info.py`**: `get_ADDITIONAL_itemInfo` gains an optional `exitOnError` passthrough (default `True`, so every other caller keeps today's behavior).
- **The four `studio_network_info` call sites** (`mumc_favorited.py` ×3, `mumc_tagged.py` ×1) pass `exitOnError=False` and skip the stale studio. The two TV-episode sites already had `if (not (tvstudionetwork_item_info == None))` guards — this just lets them do their job; the two movie sites gain the equivalent guard, styled the same way.

The diagnostic block is still printed on a 404, so the log keeps showing exactly which lookup failed — the run just continues afterward.

## How it was verified

Ran the modified lookup against a local stub HTTP server that mimics the Jellyfin `/Users/{id}/Items/{id}` endpoint (200 with item JSON for one id, 404 for another):

- existing item → fetched and parsed normally
- missing item → same diagnostic block as the issue report, returns `None` in ~0 s (no backoff), caller skips it and the run continues

Also `py_compile` on all four touched modules.

## Scope note

Other `get_ADDITIONAL_itemInfo` lookup topics (`series_info`, etc.) still exit on 404, unchanged — a stale reference is plausible there too, but I kept this PR to the crash actually reported in #178. Happy to extend the same pattern elsewhere if you'd like.

*Fix developed with AI assistance (Claude), reviewed and verified as described above.*